### PR TITLE
Wait for in-progress downloads to finish before exiting

### DIFF
--- a/toshodl.py
+++ b/toshodl.py
@@ -13,21 +13,20 @@ async def main():
     tosho = ToshoSearch()
 
     tasks = []
-    while True:
-        writer.write('waiting for input: '.encode())
-        line = await reader.readline()
-        if not line:
-            print("Done reading input!")
-            break
-        trimmed = line.decode().strip()
-        if len(trimmed) > 0:
-            id = await tosho.search(trimmed)
-            if id is not None:
-                writer.write(f'{trimmed} is id {id}\n'.encode())
-                task = ToshoResolver(id)
-
-    print("Out of the main loop")
-
+    async with asyncio.TaskGroup() as tg:
+        while True:
+            writer.write('waiting for input: '.encode())
+            line = await reader.readline()
+            if not line:
+                print("Done reading input!\nWaiting for all tasks to finish...")
+                break
+            trimmed = line.decode().strip()
+            if len(trimmed) > 0:
+                id = await tosho.search(trimmed)
+                if id is not None:
+                    writer.write(f'{trimmed} is id {id}\n'.encode())
+                    resolver = ToshoResolver(id)
+                    tg.create_task(resolver.run())
 
 if __name__ == '__main__':
     asyncio.run(main())


### PR DESCRIPTION
This should also help with displaying exceptions that occur in the download process, since we're actually waiting/joining them instead of just fire-and-forget