### PR TITLE
Try another source if we can't connect

### DIFF
--- a/toshodl/DownloadSourceBase.py
+++ b/toshodl/DownloadSourceBase.py
@@ -17,6 +17,9 @@ class DownloadSourceBase(HttpClient):
     def __str__(self):
         return f'download from { self.url }'
 
+    async def download_from_url(self):
+        raise NotImplemented(f'Class { type(self).__name__ } does not implement "download_from_url()"')
+
     def download(self):
         return self.exception_retry(lambda: self.download_from_url(),
                                     exception=httpx.TransportError,

--- a/toshodl/HttpClient.py
+++ b/toshodl/HttpClient.py
@@ -16,7 +16,7 @@ class HttpClient(Printable):
     async def exception_retry(self, fn, exception=httpx.ConnectTimeout, tries=5, delay=5, name=None):
         if name is None:
             name = self.url
-        for i in range(tries-1):
+        for i in range(tries):
             try:
                 rv = await fn()
             except exception as e:

--- a/toshodl/HttpClient.py
+++ b/toshodl/HttpClient.py
@@ -20,11 +20,16 @@ class HttpClient(Printable):
             try:
                 rv = await fn()
             except exception as e:
-                self.print(f'*** { self } Caught { type(e) } { e } attempt { i }: { name }\n')
+                self.print(f'*** { self } fn { fn } Caught { type(e) } { e } attempt { i }: { name }\n')
                 if delay and delay > 0:
                     await asyncio.sleep(delay)
+                last_exception = e
                 continue # try again
 
             # if we get here, fn() was successful
             return rv
+
+        # If we get here, we ran out of retries
+        self.print(f'*** ran out of retries, throwing a { type(last_exception) }: { last_exception }\n')
+        raise last_exception from last_exception
 


### PR DESCRIPTION
If a download source wasn't responding, leading to connect/read timeouts/errors, then the script would die.

This allows it to try another source after exhausting the connect retry count.

Part of this is a bugfix where download() should have been async from the start, necessitating calling await on the exception_retry().  This bug was a pain to track down because the non-async download() meant that the call to `dl.download()` in `FileDownloader.download_piece()` actually vanishes from the call stack and appears as

* FileDownloader.download_piece()
* calls exception_retry()
* calls ActualDownloadClass.download_from_url()

and there's no opportunity to catch the exception within DownloadSourceBase.download()